### PR TITLE
Add camera lifecycle control

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -33,17 +33,14 @@ class _MainNav extends StatefulWidget {
 
 class _MainNavState extends State<_MainNav> {
   int _current = 0;
-  final GlobalKey<_GratitudeSnapScreenState> _snapKey =
-      GlobalKey<_GratitudeSnapScreenState>();
+  final GlobalKey<GratitudeSnapScreenState> _snapKey =
+      GlobalKey<GratitudeSnapScreenState>();
 
   @override
   Widget build(BuildContext context) {
     final screens = [
       TimelineScreen(),
-      GratitudeSnapScreen(
-        key: _snapKey,
-        primaryCamera: widget.cameras.first,
-      ),
+      GratitudeSnapScreen(key: _snapKey, primaryCamera: widget.cameras.first),
     ];
 
     return Scaffold(

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -6,7 +6,7 @@ import 'screens/gratitude_snap_screen.dart';
 
 /// Root widget with bottom navigation (Timeline ⟷ Snap).
 class ApricityApp extends StatelessWidget {
-  const ApricityApp({Key? key, required this.cameras}) : super(key: key);
+  const ApricityApp({super.key, required this.cameras});
 
   final List<CameraDescription> cameras;
 
@@ -24,7 +24,7 @@ class ApricityApp extends StatelessWidget {
 }
 
 class _MainNav extends StatefulWidget {
-  const _MainNav({super.key, required this.cameras});
+  const _MainNav({required this.cameras});
   final List<CameraDescription> cameras;
 
   @override

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -33,12 +33,17 @@ class _MainNav extends StatefulWidget {
 
 class _MainNavState extends State<_MainNav> {
   int _current = 0;
+  final GlobalKey<_GratitudeSnapScreenState> _snapKey =
+      GlobalKey<_GratitudeSnapScreenState>();
 
   @override
   Widget build(BuildContext context) {
     final screens = [
       TimelineScreen(),
-      GratitudeSnapScreen(primaryCamera: widget.cameras.first),
+      GratitudeSnapScreen(
+        key: _snapKey,
+        primaryCamera: widget.cameras.first,
+      ),
     ];
 
     return Scaffold(
@@ -57,7 +62,14 @@ class _MainNavState extends State<_MainNav> {
             label: 'Snap',
           ),
         ],
-        onDestinationSelected: (i) => setState(() => _current = i),
+        onDestinationSelected: (i) {
+          if (i == 1 && _current != 1) {
+            _snapKey.currentState?.startCamera();
+          } else if (i != 1 && _current == 1) {
+            _snapKey.currentState?.stopCamera();
+          }
+          setState(() => _current = i);
+        },
       ),
     );
   }

--- a/lib/screens/gratitude_snap_screen.dart
+++ b/lib/screens/gratitude_snap_screen.dart
@@ -12,10 +12,10 @@ class GratitudeSnapScreen extends StatefulWidget {
   final CameraDescription primaryCamera;
 
   @override
-  State<GratitudeSnapScreen> createState() => _GratitudeSnapScreenState();
+  State<GratitudeSnapScreen> createState() => GratitudeSnapScreenState();
 }
 
-class _GratitudeSnapScreenState extends State<GratitudeSnapScreen> {
+class GratitudeSnapScreenState extends State<GratitudeSnapScreen> {
   CameraController? _controller;
   Future<void>? _initCameraFuture;
   XFile? _capturedImage;
@@ -106,57 +106,57 @@ class _GratitudeSnapScreenState extends State<GratitudeSnapScreen> {
           : FutureBuilder(
               future: _initCameraFuture,
               builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.done) {
-            return Column(
-              children: [
-                Expanded(
-                  child: _capturedImage == null
-                      ? CameraPreview(_controller!)
-                      : Image.file(
-                          File(_capturedImage!.path),
-                          fit: BoxFit.cover,
-                        ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(12.0),
-                  child: TextField(
-                    controller: _captionController,
-                    decoration: const InputDecoration(
-                      labelText: 'What are you grateful for?',
-                      border: OutlineInputBorder(),
-                    ),
-                    maxLines: null,
-                  ),
-                ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  children: [
-                    FloatingActionButton(
-                      heroTag: 'snap',
-                      onPressed: _takePicture,
-                      child: const Icon(Icons.photo_camera),
-                    ),
-                    if (_capturedImage != null)
-                      FilledButton.icon(
-                        onPressed: _isUploading ? null : _submitEntry,
-                        icon: _isUploading
-                            ? const SizedBox(
-                                width: 18,
-                                height: 18,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
-                              )
-                            : const Icon(Icons.send),
-                        label: const Text('Save'),
+                if (snapshot.connectionState == ConnectionState.done) {
+                  return Column(
+                    children: [
+                      Expanded(
+                        child: _capturedImage == null
+                            ? CameraPreview(_controller!)
+                            : Image.file(
+                                File(_capturedImage!.path),
+                                fit: BoxFit.cover,
+                              ),
                       ),
-                  ],
-                ),
-                const SizedBox(height: 16),
-              ],
-            );
-          }
-          return const Center(child: CircularProgressIndicator());
+                      Padding(
+                        padding: const EdgeInsets.all(12.0),
+                        child: TextField(
+                          controller: _captionController,
+                          decoration: const InputDecoration(
+                            labelText: 'What are you grateful for?',
+                            border: OutlineInputBorder(),
+                          ),
+                          maxLines: null,
+                        ),
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          FloatingActionButton(
+                            heroTag: 'snap',
+                            onPressed: _takePicture,
+                            child: const Icon(Icons.photo_camera),
+                          ),
+                          if (_capturedImage != null)
+                            FilledButton.icon(
+                              onPressed: _isUploading ? null : _submitEntry,
+                              icon: _isUploading
+                                  ? const SizedBox(
+                                      width: 18,
+                                      height: 18,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                      ),
+                                    )
+                                  : const Icon(Icons.send),
+                              label: const Text('Save'),
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+                  );
+                }
+                return const Center(child: CircularProgressIndicator());
               },
             ),
     );

--- a/lib/screens/timeline_screen.dart
+++ b/lib/screens/timeline_screen.dart
@@ -1,10 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:camera/camera.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-
-import 'gratitude_snap_screen.dart';
 
 /// ---------------------------------------------
 /// TimelineScreen


### PR DESCRIPTION
## Summary
- keep the Snap screen state alive with a `GlobalKey`
- manage `CameraController` via new `startCamera()` and `stopCamera()`
- toggle camera when navigating between Timeline and Snap

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841afc413548321b3166c730c84db2a